### PR TITLE
Fix indentation in application layout so browser tab name displays correctly

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -3,9 +3,9 @@ html lang='en'
   head
     meta charset='utf-8'
     title ToTheVictor
-      = stylesheet_link_tag 'application', media: 'all'
-      = javascript_include_tag 'application'
-      = favicon_link_tag
+    = stylesheet_link_tag 'application', media: 'all'
+    = javascript_include_tag 'application'
+    = favicon_link_tag
 
   body
     div


### PR DESCRIPTION
#13

<img width="288" alt="screen shot 2016-02-19 at 10 30 57 am" src="https://cloud.githubusercontent.com/assets/5957963/13179862/ff1e6b7e-d6f3-11e5-8690-884bcb242a64.png">
